### PR TITLE
Add install instructions for `Package.swift`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,31 @@
 
 SwiftyLua is a Swift wrapper and bridge for Lua.
 
-## Usage
+## Example Usage
 
 You can find usage examples in the test spec [UsageSpec.swift](./Tests/SwiftyLuaTests/UsageSpec.swift).
+
+
+## Installation
+
+Reference this project in your `Package.swift` like so:
+
+```swift
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "LuaTest",
+    dependencies: [ .package(url: "https://github.com/SwiftyLua/SwiftyLua.git", from: "0.0.2") ],
+    targets: [
+        .executableTarget(
+            name: "LuaTest",
+            dependencies: [ .product(name: "SwiftyLua", package: "SwiftyLua") ]
+        ),
+    ]
+)
+```
 
 ## Licenses
 


### PR DESCRIPTION
I'm not too sure if using Lua is allowed in iOS applications, so I think most people will be using it with executable swift packages (for games, CLI tools or whatever).

Install instructions might come in handy